### PR TITLE
Refactor into a class for external usage

### DIFF
--- a/lex_to_lives.rb
+++ b/lex_to_lives.rb
@@ -40,9 +40,9 @@ class LexToLIVES
 
     csv_parse(infile)
 
-    csv_write(businesses_csv_file, Business.members, businesses.uniq)
-    csv_write(inspections_csv_file, Inspection.members, inspections.uniq)
-    csv_write(violations_csv_file, Violation.members, violations.uniq)
+    csv_write(businesses_csv_file, Business.members, businesses)
+    csv_write(inspections_csv_file, Inspection.members, inspections)
+    csv_write(violations_csv_file, Violation.members, violations)
   end
 
   # Read Lexington-format CSV file, parse into internal data structs.
@@ -57,6 +57,10 @@ class LexToLIVES
       inspections << parse_inspection(entry)
       violations  << parse_violation(entry)
     end
+
+    businesses.uniq!
+    inspections.uniq!
+    violations.uniq!
   end
 
   # Write LIVES-format CSV file from internal data structs.


### PR DESCRIPTION
## What's new

This wraps all the logic up into a class so it can be required/used/tested externally. It has a stub so it can still be executed at the command line, taking an input file as an argument.
## Refactor

I ended up moving more stuff around than I'd planned. =) I added Struct-based objects for businesses, inspections, and violations which has the side benefit of making the Lex-to-LIVES mapping clearer. I moved the reading/parsing/writing out into their own methods to make them all smaller.

The CSV read and write methods are left public, mainly for (as-yet-unwritten) tests. The #transform method wraps these two, so a test might want to read-but-not-write, or inject custom data into the transformer before writing. There's probably more to do for testability, like allowing the input and output files to be IO objects so tests could inject StringIO instead of using the filesystem.

[:ocean: :ocean: :ocean:](https://www.youtube.com/watch?v=bjdODmRD9m4)
