### PR TITLE
Update README usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Assembled by OpenLexington for Code Across America 2013
 * Download [most_recent_food_scores](http://www.lexingtonhealthdepartment.org/Portals/0/environmental%20health/most_recent_food_scores.xls) xls file
 * `ruby xls_to_csv.rb` # outputs most_recent_food_scores.csv
 * `./lex_to_lives.rb most_recent_food_scores.csv`
-* zip most_recent_food_scores.zip -xi {businesses,inspections,violations}.csv
+* `zip most_recent_food_scores.zip {businesses,inspections,violations}.csv`


### PR DESCRIPTION
No need for `zip -xi`, which are actually [two separate options](http://linuxcommand.org/man_pages/zip1.html) (e**x**clude files, **i**nclude files).

Could be cherry-picked over to the `gh-pages` branch, too, if that matters.