### PR TITLE
Health dept link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,10 @@ heroku repo:purge_cache -a my-etl-app
 Add Heroku Scheduler add-on to Heroku instance
 
 set to run daily:
-`bundle exec ruby lives_etl.erb`
+`bundle exec ruby lives_etl.rb`
+
+## To check when scores have changed on the Health Dept page
+
+Use http://www.changedetection.com/monitor.html
+
+That way you get a notification that the scores have changed and the automation should have kicked off.

--- a/lives_etl.rb
+++ b/lives_etl.rb
@@ -9,7 +9,7 @@ require 'net/http'
 require 'dotenv'
 Dotenv.load
 
-HEALTH_DEPT_PERMALINK = 'http://www.lexingtonhealthdepartment.org/Portals/0/environmental%20health/most_recent_food_scores.xls'
+HEALTH_DEPT_PERMALINK = 'http://lexingtonhealthdepartment.org/Portals/0/most_recent_food_scores.xls'
 
 TEMPDIR = Dir.mktmpdir
 clone_url = 'https://github.com/openlexington/health-department-yelp-data.git'


### PR DESCRIPTION
If the permalink ends up changing often, we can set it as an argument to `lives_etl.rb`

Also updated the readme for some manual monitoring until we build that into the automation. #25 